### PR TITLE
Upgrade bunsen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ Use a `# CHANGELOG` section in your Pull Request description to auto-populate th
 - **BREAKING** Using [ember-remodal](http://sethbrasile.github.io/ember-remodal/) addon to simplify modal dialog support. Additional modal-input template options required
 
 ## Removed
-- **BREAKING** Removed liquid-fire modal code. 
+- **BREAKING** Removed liquid-fire modal code.
   - Removed the need to define/import transitions and configure the router.js file
 
 ## Upgrade notes
-If you are upgrading your app to use this version, note the following - 
+If you are upgrading your app to use this version, note the following -
 - Remove the modal declaration from your router.js file
 - Remove any import statement from your modal component file that is importing transitions from frost-modal-input
 - Remove `{{liquid-modal}}` template code if you do not have any other liquid-fire modals in your app
 - Apply `remodal-bg` class to the parent container where you want a blur effect on the modal overlay.
-- `frost-modal-input` root template must use block-slots and contain `ember-frost-bunsen-form` attrs - formView/formModel/formValue/onChange/onValidation. See README for details.
-
+- `frost-modal-input` root template must use block-slots and contain `frost-bunsen-form` attrs - formView/formModel/formValue/onChange/onValidation. See README for details.

--- a/addon/components/frost-modal-input.js
+++ b/addon/components/frost-modal-input.js
@@ -11,6 +11,8 @@ export default Component.extend({
   $containerEl: null,
   $headerEl: null,
   $footerEl: null,
+  renderers: {},
+  validators: [],
 
   /**
    * create a window.MutationObserver on the container element

--- a/addon/components/frost-modal-input.js
+++ b/addon/components/frost-modal-input.js
@@ -1,18 +1,65 @@
 /* global Ps */
 import Ember from 'ember'
-import layout from '../templates/components/frost-modal-input'
-
 const {Component} = Ember
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
-export default Component.extend({
-  layout,
+export default Component.extend(PropTypeMixin, {
+  // ==========================================================================
+  // Dependencies
+  // ==========================================================================
+
+  // ==========================================================================
+  // Properties
+  // ==========================================================================
+
   scrollBindingsSet: false,
   containerObserver: null,  // @type {window.MutationObserver}
   $containerEl: null,
   $headerEl: null,
   $footerEl: null,
-  renderers: {},
-  validators: [],
+
+  propTypes: {
+    formModel: PropTypes.oneOfType([
+      PropTypes.EmberObject,
+      PropTypes.object
+    ]).isRequired,
+    formValue: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.EmberObject
+    ]),
+    formView: PropTypes.oneOfType([
+      PropTypes.EmberObject,
+      PropTypes.object
+    ]),
+    modalName: PropTypes.string,
+    onChange: PropTypes.func,
+    onValidation: PropTypes.func,
+    renderers: PropTypes.oneOfType([
+      PropTypes.EmberObject,
+      PropTypes.object
+    ]),
+    showAllErrors: PropTypes.bool,
+    subtitle: PropTypes.string,
+    title: PropTypes.string,
+    titleComponent: PropTypes.string,
+    validators: PropTypes.array
+  },
+
+  getDefaultProps () {
+    return {
+      renderers: {},
+      showAllErrors: false,
+      validators: []
+    }
+  },
+
+  // ==========================================================================
+  // Computed Properties
+  // ==========================================================================
+
+  // ==========================================================================
+  // Functions
+  // ==========================================================================
 
   /**
    * create a window.MutationObserver on the container element
@@ -36,10 +83,10 @@ export default Component.extend({
   },
 
   /**
-  * update perfect-scrollbar before checking scoll position
-  * need to disconnect MutationObserver then re-establish to prevent infinite loop
-  * of mutation event triggers, callback updates, which triggers new mutation event...
-  */
+   * update perfect-scrollbar before checking scoll position
+   * need to disconnect MutationObserver then re-establish to prevent infinite loop
+   * of mutation event triggers, callback updates, which triggers new mutation event...
+   */
   updatePerfectScrollbar () {
     let mutationObserver
     const $containerEl = this.get('$containerEl')
@@ -60,8 +107,8 @@ export default Component.extend({
   },
 
   /**
-  * Checks scroll position within container element to add/remove scroll styling to header/footer elements
-  */
+   * Checks scroll position within container element to add/remove scroll styling to header/footer elements
+   */
   updateScrollStyles () {
     const $containerEl = this.get('$containerEl')
     const $headerEl = this.get('$headerEl')
@@ -111,6 +158,14 @@ export default Component.extend({
   didRender () {
     Ember.$('.ember-remodal.window').addClass('frost-modal-input')
   },
+
+  // ==========================================================================
+  // Events
+  // ==========================================================================
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
 
   actions: {
     modalOpen () {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -101,7 +101,7 @@ $scroll-box-shadow: rgba(0, 0, 0, .25);
                 }
               }
 
-              .frost-bunsen-container {
+              form > .frost-bunsen-container {
                 margin-bottom: $action-bar-height + $form-margin-bottom;
               }
 

--- a/addon/templates/components/frost-modal-input.hbs
+++ b/addon/templates/components/frost-modal-input.hbs
@@ -33,11 +33,15 @@
     minScrollbarLength=20
     maxScrollbarLength=150}}
     {{frost-bunsen-form
-      model=formModel
-      view=formView
-      value=formValue
+      bunsenModel=formModel
+      bunsenView=formView
+      inline=true
       onChange=onChange
       onValidation=onValidation
+      renderers=renderers
+      showAllErrors=showAllErrors
+      value=formValue
+      validators=validators
       }}
   {{/perfect-scroll}}
 

--- a/app/templates/components/frost-modal-input.hbs
+++ b/app/templates/components/frost-modal-input.hbs
@@ -32,17 +32,19 @@
     wheelSpeed=2
     minScrollbarLength=20
     maxScrollbarLength=150}}
-    {{frost-bunsen-form
-      bunsenModel=formModel
-      bunsenView=formView
-      inline=true
-      onChange=onChange
-      onValidation=onValidation
-      renderers=renderers
-      showAllErrors=showAllErrors
-      value=formValue
-      validators=validators
-      }}
+    {{#if formModel}}
+      {{frost-bunsen-form
+        bunsenModel=formModel
+        bunsenView=formView
+        inline=true
+        onChange=onChange
+        onValidation=onValidation
+        renderers=renderers
+        showAllErrors=showAllErrors
+        value=formValue
+        validators=validators
+        }}
+      {{/if}}
   {{/perfect-scroll}}
 
   {{#yield-slot 'footer'}}

--- a/blueprints/ember-frost-modal-input/index.js
+++ b/blueprints/ember-frost-modal-input/index.js
@@ -11,6 +11,7 @@ module.exports = {
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [
+        {name: 'ember-frost-bunsen', target: '^6.0.3'},
         {name: 'ember-frost-core', target: '>=0.0.14 <2.0.0'},
         {name: 'ember-block-slots', target: '^0.12.2'},
         {name: 'ember-perfectscroll', target: '^0.1.2'},

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-data": "^2.4.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-frost-bunsen": "^5.12.2",
+    "ember-frost-bunsen": "^6.0.3",
     "ember-frost-core": ">=0.9.2 <2.0.0",
     "ember-frost-info-bar": "^2.1.0",
     "ember-load-initializers": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-one-way-controls": "^0.8.0",
     "ember-perfectscroll": "0.1.2",
     "ember-prism": "0.0.7",
-    "ember-prop-types": "^1.3.0",
+    "ember-prop-types": "^2.0.0",
     "ember-redux": "1.3.0",
     "ember-remodal": "1.2.0",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
#MAJOR#

# CHANGELOG

## Breaking

* **Upgraded** [ember-frost-bunsen](https://github.com/ciena-frost/ember-frost-bunsen) to version `6.0.3`.
* **Upgraded** [ember-prop-types](https://github.com/ciena-blueplanet/ember-prop-types) to version `2.0.0`.

## Non-Breaking

* **Added** `renderers` property for passing renderers to `frost-bunsen-form`.
* **Added** `showAllErrors` property for whether or not form should show all errors.
* **Added** `validators` property for passing validators to `frost-bunsen-form`.
* **Updated** component to use [ember-prop-types](https://github.com/ciena-blueplanet/ember-prop-types) for property validation.