### PR TITLE
Set min-width of buttons rather than width

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -142,7 +142,7 @@ $scroll-box-shadow: rgba(0, 0, 0, .25);
                 z-index: 999;
 
                 > .frost-button {
-                  width: 150px;
+                  min-width: 150px;
                   margin-left: 10px;
                 }
 


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Changed** dialog footer buttons from a fixed width of `150px` to have a minimum width of `150px`.