### PR TITLE
Closes ciena-frost/ember-frost-modal-input#39

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,5 @@
 'use strict'
 
 module.exports = {
-  name: 'ember-frost-modal-input',
-
-  included: function (app) {
-    this._super.included(app)
-  }
+  name: 'ember-frost-modal-input'
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* #39 - Bind context to call of this._super.included() in index.js